### PR TITLE
Linter clean-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Go
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Uploade Code Coverage
+    - name: Upload Code Coverage
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,11 @@ jobs:
       
     - name: Test
       run: make test
+
+    - name: Uploade Code Coverage
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        files: ./coverage.txt               # optional
+        fail_ci_if_error: true              # optional (default = false)
+        verbose: true                       # optional (default = false)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,6 +35,11 @@ jobs:
         language: [ 'go' ]
 
     steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
     - name: Checkout repository
       uses: actions/checkout@v2
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,8 +33,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
     - name: Checkout repository
@@ -54,17 +52,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      run: make build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,8 +50,7 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    - name: Build
       run: make build
 
     - name: Perform CodeQL Analysis

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ artifacts/
 
 # Test binary, built with `go test -c`
 *.test
+/coverage.txt
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,9 +18,32 @@ linters:
   enable-all: true
   disable:
     - exhaustivestruct
+    - golint
+    - interfacer
+    - maligned
     - noctx
+    - scopelint
 
 linters-settings:
+  ireturn:
+    # ireturn allows using `allow` and `reject` settings at the same time.
+    # Both settings are lists of the keywords and regular expressions matched to interface or package names.
+    # keywords:
+    # - `empty` for `interface{}`
+    # - `error` for errors
+    # - `stdlib` for standard library
+    # - `anon` for anonymous interfaces
+
+    # By default, it allows using errors, empty interfaces, anonymous interfaces,
+    # and interfaces provided by the standard library.
+    # You can specify idiomatic endings for interface
+    allow:
+      - anon
+      - error
+      - empty
+      - stdlib
+      - .*Sqlmock
+
   lll:
     # max line length, lines longer will be reported.
     # Note how [Effective Go](https://go.dev/doc/effective_go#formatting) doesn't recommend a fixed maximum:

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,13 @@ clean:
 	rm -rf $(BUILD_ARTIFACTS_DIR)
 
 dep:
+	go mod tidy
 	go mod download
 
 lint:
+	golangci-lint run --enable-all
+
+lint-fix:
 	golangci-lint run --enable-all --fix
 
 test: lint
@@ -27,12 +31,12 @@ test: lint
 
 build: dep
 	mkdir -p $(BIN_DIR)
-	go build -ldflags "-X main.Version=$(VERSION)" -o $(BIN_DIR)/$(BIN_FILE)-${GOOS}-${GOARCH}
+	go build -ldflags "-X main.Version=$(VERSION)" -o $(BIN_DIR)/$(BIN_FILE)-$(GOOS)-$(GOARCH)
 
 .PHONY: run
 run: build
 	mkdir -p $(DB_DIR)
-	$(BIN_DIR)/$(BIN_FILE)
+	$(BIN_DIR)/$(BIN_FILE)-$(GOOS)-$(GOARCH)
 
 .PHONY: version
 version:

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clean:
 	rm -rf $(BUILD_ARTIFACTS_DIR)
 
 dep:
+	go get -t -v ./...
 	go mod tidy
 	go mod download
 
@@ -27,7 +28,7 @@ lint-fix:
 	golangci-lint run --enable-all --fix
 
 test: lint
-	go test
+	go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 build: dep
 	mkdir -p $(BIN_DIR)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ other services (e.g. 802.1X Wi-Fi, vpn server).
 
 The fringe service offers both a http and radius server. 
 * The web interface allows authenticated users (through Google Oauth) to generate and refresh a randomly generated 
-password (only for users in a pecific email domain). 
+password (only for users in a specific email domain). 
 * The radius server authenticate the user using email and generated password.
 
 ## Getting Started 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Fringe
+[![codecov](https://codecov.io/gh/p-l/fringe/branch/main/graph/badge.svg?token=A23DESO0EP)](https://codecov.io/gh/p-l/fringe)
 
 **Fringe** is an easy workaround for Google Workplace users who need a Radius server to perform authentication on behalf of
 other services (e.g. 802.1X Wi-Fi, vpn server). 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fringe
 [![codecov](https://codecov.io/gh/p-l/fringe/branch/main/graph/badge.svg?token=A23DESO0EP)](https://codecov.io/gh/p-l/fringe)
+![ci workflow](https://github.com/p-l/fringe/actions/workflows/ci.yml/badge.svg)
+![codeql workflow](https://github.com/p-l/fringe/actions/workflows/codeql-analysis.yml/badge.svg)
 
 **Fringe** is an easy workaround for Google Workplace users who need a Radius server to perform authentication on behalf of
 other services (e.g. 802.1X Wi-Fi, vpn server). 

--- a/go.mod
+++ b/go.mod
@@ -3,23 +3,23 @@ module github.com/p-l/fringe
 go 1.17
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/alexedwards/argon2id v0.0.0-20211130144151-3585854a6387
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/jaswdr/faker v1.8.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/spf13/viper v1.9.0
+	github.com/stretchr/testify v1.7.0
 	layeh.com/radius v0.0.0-20210819152912-ad72663a72ab
 	modernc.org/ql v1.4.0
 )
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/golang/mock v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/jaswdr/faker v1.8.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
@@ -29,7 +29,6 @@ require (
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bxcodec/faker/v3 v3.6.0 h1:Meuh+M6pQJsQJwxVALq6H5wpDzkZ4pStV9pmH7gbKKs=
-github.com/bxcodec/faker/v3 v3.6.0/go.mod h1:gF31YgnMSMKgkvl+fyEo1xuSMbEuieyqfeslGYFjneM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -110,7 +108,6 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -214,8 +211,6 @@ github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
-github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d h1:Zj+PHjnhRYWBK6RqCDBcAhLXoi3TzC27Zad/Vn+gnVQ=
-github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d/go.mod h1:WZy8Q5coAB1zhY9AOBJP0O6J4BuDfbupUDavKY+I3+s=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/internal/repositories/user_repository_test.go
+++ b/internal/repositories/user_repository_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func dbOpen() (*sqlx.DB, sqlmock.Sqlmock) { //nolint:ireturn
+func dbOpen() (*sqlx.DB, sqlmock.Sqlmock) {
 	mockDB, mockSQL, err := sqlmock.New()
 	if err != nil {
 		log.Panicf("FATAL: an error '%s' was not expected when opening a stub database connection", err)


### PR DESCRIPTION
* Configure some of the linters defaults to match the project
* Remove remaining warnings
* Clean-up the `Makefile` (not lint related but GitHub Actions use the `Makefile` to initiate lifting (`make lint`)
  * Added `make lint-fix` to auto-fix linting issue when ran locally
  * Made `make run` use the full binary name (with Arch and OS)